### PR TITLE
fix: trim spaces on git rev-list --count

### DIFF
--- a/internal/git/git_cli.go
+++ b/internal/git/git_cli.go
@@ -36,7 +36,7 @@ func (g *GitCLIBackend) GetCommitCount(ref Ref) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.Atoi(out)
+	return strconv.Atoi(strings.TrimSpace(out))
 }
 
 func (g *GitCLIBackend) GetTag(ref Ref) (string, error) {


### PR DESCRIPTION
to fix

> error: cannot setup project properties: strconv.Atoi: parsing "267\n": invalid syntax